### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/peter-murach/tty.png?branch=master)][travis]
 [![Code Climate](https://codeclimate.com/github/peter-murach/tty.png)][codeclimate]
 [![Coverage Status](https://coveralls.io/repos/peter-murach/tty/badge.png?branch=master)][coveralls]
+[![Inline docs](http://inch-ci.org/github/peter-murach/tty.png?branch=master)](http://inch-ci.org/github/peter-murach/tty)
 
 [gem]: http://badge.fury.io/rb/tty
 [travis]: http://travis-ci.org/peter-murach/tty


### PR DESCRIPTION
Hi Piotr,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/peter-murach/tty.png)](http://inch-ci.org/github/peter-murach/tty)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/peter-murach/tty/

What do you think?
