### PR TITLE
Add #read_keypress to Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ read_regex      # return regex expression
 read_string     # return string
 read_symbol     # return symbol
 read_text       # return multiline string
+read_keypress   # return the key pressed
 ```
 
 For example, if we wanted to ask a user for a single digit in given range

--- a/lib/tty.rb
+++ b/lib/tty.rb
@@ -35,6 +35,7 @@ require 'tty/shell/reader'
 require 'tty/shell/response'
 
 require 'tty/terminal/echo'
+require 'tty/terminal/raw'
 require 'tty/terminal/home'
 require 'tty/terminal/pager'
 require 'tty/terminal/pager/basic'

--- a/lib/tty/shell/question.rb
+++ b/lib/tty/shell/question.rb
@@ -56,6 +56,7 @@ module TTY
         @shell         = shell || Shell.new
         @required      = options.fetch(:required) { false }
         @echo          = options.fetch(:echo) { true }
+        @raw           = options.fetch(:raw) { false }
         @mask          = options.fetch(:mask) { false  }
         @character     = options.fetch(:character) { false }
         @in            = options.fetch(:in) { false }
@@ -196,6 +197,22 @@ module TTY
       # @api public
       def echo?
         !!@echo
+      end
+
+      # Turn raw mode on or off. This enables character-based input.
+      #
+      # @api public
+      def raw(value = nil)
+        return @raw if value.nil?
+        @raw = value
+        self
+      end
+
+      # Check if raw mode is set
+      #
+      # @api public
+      def raw?
+        !!@raw
       end
 
       # Set character for masking the STDIN input

--- a/lib/tty/shell/reader.rb
+++ b/lib/tty/shell/reader.rb
@@ -75,6 +75,15 @@ module TTY
         shell.input.gets
       end
 
+      # Reads at maximum +maxlen+ characters.
+      #
+      # @param [Integer] maxlen
+      #
+      # @api public
+      def readpartial(maxlen)
+        shell.input.readpartial(maxlen)
+      end
+
       private
 
       # Handle single character by appending to or removing from output

--- a/lib/tty/shell/response.rb
+++ b/lib/tty/shell/response.rb
@@ -59,7 +59,15 @@ module TTY
           reader.getc(question.mask)
         else
           TTY.terminal.echo(question.echo) do
-            question.character? ? reader.getc(question.mask) : reader.gets
+            TTY.terminal.raw(question.raw) do
+              if question.raw?
+                reader.readpartial(10)
+              elsif question.character?
+                reader.getc(question.mask)
+              else
+                reader.gets
+              end
+            end
           end
         end
       end
@@ -191,6 +199,17 @@ module TTY
       def read_password
         question.echo false
         question.evaluate_response read_input
+      end
+
+      # Read a single keypress
+      #
+      # @api public
+      def read_keypress
+        question.echo false
+        question.raw true
+        question.evaluate_response(read_input).tap do |key|
+          raise Interrupt if key == "\x03" # Ctrl-C
+        end
       end
 
       private

--- a/lib/tty/shell/response_delegation.rb
+++ b/lib/tty/shell/response_delegation.rb
@@ -39,6 +39,8 @@ module TTY
 
       delegatable_method :dispatch, :read_password
 
+      delegatable_method :dispatch, :read_keypress
+
       # Create response instance when question readed is invoked
       #
       # @param [TTY::Shell::Response] response

--- a/lib/tty/terminal.rb
+++ b/lib/tty/terminal.rb
@@ -22,6 +22,7 @@ module TTY
     def initialize(options = {})
       @color = Pastel.new
       @echo  = TTY::Terminal::Echo.new
+      @raw   = TTY::Terminal::Raw.new
       @pager = TTY::Terminal::Pager
       @home  = Home.new
     end
@@ -47,6 +48,29 @@ module TTY
     # @api public
     def echo(is_on = true, &block)
       @echo.echo(is_on, &block)
+    end
+
+    # Switch raw mode on
+    #
+    # @api public
+    def raw_on
+      @raw.on
+    end
+
+    # Switch raw mode off
+    #
+    # @api public
+    def raw_off
+      @raw.off
+    end
+
+    # Use raw mode in the given block
+    #
+    # @param [Boolean] is_on
+    #
+    # @api public
+    def raw(is_on = true, &block)
+      @raw.raw(is_on, &block)
     end
 
     # Find user home directory

--- a/lib/tty/terminal/raw.rb
+++ b/lib/tty/terminal/raw.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+module TTY
+  class Terminal
+    # A class responsible for toggling raw mode.
+    class Raw
+      # Turn raw mode on
+      #
+      # @api public
+      def on
+        %x{stty raw} if TTY::System.unix?
+      end
+
+      # Turn raw mode off
+      #
+      # @api public
+      def off
+        %x{stty -raw} if TTY::System.unix?
+      end
+
+      # Wrap code block inside raw mode
+      #
+      # @api public
+      def raw(is_on=true, &block)
+        value = nil
+        begin
+          on if is_on
+          value = block.call if block_given?
+          off
+          return value
+        rescue NoMethodError, Interrupt
+          off
+          exit
+        end
+      end
+    end # Echo
+  end # Terminal
+end # TTY


### PR DESCRIPTION
Sometimes we want to read a single keypress from the user. This will read any keypress, no matter how many characters it is.

``` rb
require "tty"

shell = TTY::Shell.new
key = shell.ask("Press a key: ").read_keypress

case key
when "\e[A" then puts "Up"
when "\e[B" then puts "Down"
when "\e[C" then puts "Right"
when "\e[D" then puts "Left"
...
end
```

I didn't know how to write tests for it, because it wouldn't work on `StringIO`s (since it's a Terminal option). I wanted to somehow use `IO#raw`, but it seemed to complicated, because `IO#raw` already includes disabling echo. And if I did that, then I would also have to use `IO#noecho` for echoing to be consistent :smiley:

Fixes #10.
