### PR TITLE
Require version on `new` command (bugfix for #35)

### DIFF
--- a/lib/tty/commands/new.rb
+++ b/lib/tty/commands/new.rb
@@ -10,6 +10,8 @@ require_relative '../gemspec'
 require_relative '../licenses'
 require_relative '../plugins'
 require_relative '../templater'
+require_relative '../version'
+
 
 module TTY
   module Commands


### PR DESCRIPTION
Fixes issue #35. I feel that requiring `version` in `commands/new.rb` is better than altering that `plugins.rb` that you suggested (at least it was easier! :D).