### PR TITLE
Remove Bundler 2.0 restriction

### DIFF
--- a/tty.gemspec
+++ b/tty.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pastel',          '~> 0.7.2'
 
   spec.add_dependency 'thor',    '~> 0.20.0'
-  spec.add_dependency 'bundler', '~> 1.16', '< 2.0'
+  spec.add_dependency 'bundler', '>= 1.16'
 
   spec.add_development_dependency 'rspec', "~> 3.0"
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Allows Bundler >= 2.0 in addition to the existing set (' ~> 1.16') by removing the upper limit on Bundler version.

### Describe the change
This PR resolves #50 by updating the Gemfile to allow Bundler >=2.0.

### Why are we doing this?
We're doing this to allow TTY to be used with modern versions of Bundler.

### Drawbacks
None that I could see.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally? (Tested by creating project using local fork of gem)
[] Code style checked?
[] Rebased with `master` branch?
[] Documentaion updated?