### PR TITLE
Allow bundler 2

### DIFF
--- a/tty.gemspec
+++ b/tty.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pastel',          '~> 0.7.2'
 
   spec.add_dependency 'thor',    '~> 0.20.0'
-  spec.add_dependency 'bundler', '~> 1.16', '< 2.0'
+  spec.add_dependency 'bundler', '>= 1.16', '< 3'
 
   spec.add_development_dependency 'rspec', "~> 3.0"
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
### Describe the change
Allow bundler 2.0.

### Why are we doing this?
After the latest release v0.9.1 was released, bundler 2.0 has been released. 

### Benefits
Users can choose bundler 1 or 2 which they want.

### Drawbacks
With quick test, nothing. It works perfectly both bundler 1.17.3 and 2.0.1.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[] Documentaion updated?
