### PR TITLE
[ISSUE-60] Eliminates deprecation warnings during spec runs with 2.7.0

### DIFF
--- a/lib/tty/cmd.rb
+++ b/lib/tty/cmd.rb
@@ -30,7 +30,7 @@ module TTY
     # @api public
     def command(**options)
       require 'tty-command'
-      TTY::Command.new(options)
+      TTY::Command.new(**options)
     end
 
     # The cursor movement

--- a/lib/tty/commands/new.rb
+++ b/lib/tty/commands/new.rb
@@ -222,7 +222,7 @@ module TTY
                   "Copyright (c) #{Time.now.year} #{author}. "\
                   "See [#{desc}](LICENSE.txt) for further details."
         within_root_path do
-          generator.append_to_file(readme_path, content, file_options)
+          generator.append_to_file(readme_path, content, **file_options)
         end
       end
 
@@ -246,7 +246,7 @@ module TTY
         within_root_path do
           path = app_path.join(gemspec_name)
           generator.inject_into_file(path, content,
-            { before: /^\s*spec\.add_development_dependency\s*"bundler.*$/ }
+            **{ before: /^\s*spec\.add_development_dependency\s*"bundler.*$/ }
             .merge(file_options))
         end
       end

--- a/lib/tty/templater.rb
+++ b/lib/tty/templater.rb
@@ -45,7 +45,7 @@ module TTY
         next unless ::File.exist?(source)
         within_root_path do
           TTY::File.copy_file(source, destination,
-                    { context: template_options }.merge(color_option))
+                    **{ context: template_options }.merge(color_option))
         end
       end
     end


### PR DESCRIPTION
### Describe the change
Gets rid of deprecation warnings in 2.7.0p0

### Why are we doing this?
In order to use tty with ruby 2.7.

### Benefits
Stays up to date with new ruby versions

### Drawbacks
Could be problems with ruby < 2.1
This also has to be done for the supporting TTY libraries for the full specs to pass (tty-file and tty-command have many of these warnings).

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[] Documentaion updated?
