### PR TITLE
Correct method names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ will generate the following:
 module App
   class CLI < Thor
     desc 'set NAME VALUE', 'Set configuration option'
-    def config(name, value)
+    def set(name, value)
       ...
     end
   end
@@ -441,7 +441,7 @@ which will append `...` to the argument description:
 module App
   class CLI < Thor
     desc 'get NAMES...', 'Get configuration options'
-    def config(*names)
+    def get(*names)
       ...
     end
   end


### PR DESCRIPTION
### Describe the change
Change method names in README.md.

### Why are we doing this?
There are small typos in README.md which should be removed:
1. `teletype add get --args "*names"` generates `get` method not `config`.
2. `teletype add set --args name value` generates `set` method not `config`.

### Benefits
Removed errors from the documentation/usage description.

### Drawbacks
None

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[X] Documentaion updated?
