### PR TITLE
#57 Escape app path

### DIFF
--- a/lib/tty/commands/new.rb
+++ b/lib/tty/commands/new.rb
@@ -3,6 +3,7 @@
 require 'pastel'
 require 'pathname'
 require 'ostruct'
+require 'shellwords'
 
 require_relative '../cmd'
 require_relative '../gemspec'
@@ -113,7 +114,7 @@ module TTY
         ext_opt  = options['ext'] ? '--ext' : '--no-ext'
         test_opt = options['test']
         command = [
-          "bundle gem #{target_path}",
+          "bundle gem #{target_path.to_s.shellescape}",
           '--no-mit',
           '--no-exe',
           coc_opt,

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -268,25 +268,19 @@ end
     end
   end
 
-  context "when app directory contains a whitespace" do
-    subject(:create_app) { Open3.capture3(command) }
+  it "does not raise errors if app directory contains whitespace" do
+    app_directory = "weird dir"
+    FileUtils.mkdir_p("./tmp/#{app_directory}")
 
-    let(:app_directory) { "weird dir" }
-    let(:command) do
-      "teletype new app --no-coc --no-color --license mit --no-ext"
+    command = "teletype new app --no-coc --no-color --license mit --no-ext"
+
+    within_dir("./tmp/#{app_directory}") do
+      _out, err, _status = Open3.capture3(command)
+      puts err
+      expect(err).to eq("")
     end
 
-    before { FileUtils.mkdir_p("./tmp/#{app_directory}") }
-
-    after { FileUtils.rm_r("./tmp/#{app_directory}") }
-
-    it "does not raise errors" do
-      within_dir("./tmp/#{app_directory}") do
-        _out, err, _status = create_app
-        puts err
-        expect(err).to eq('')
-      end
-    end
+    FileUtils.rm_r("./tmp/#{app_directory}")
   end
 
   it "generates C extensions boilerplate" do

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -272,7 +272,9 @@ end
     subject(:create_app) { Open3.capture3(command) }
 
     let(:app_directory) { "weird dir" }
-    let(:command) { "teletype new app --no-coc --no-color --license mit --no-ext" }
+    let(:command) do
+      "teletype new app --no-coc --no-color --license mit --no-ext"
+    end
 
     before { FileUtils.mkdir_p("./tmp/#{app_directory}") }
 
@@ -300,7 +302,7 @@ end
     out, err, status = Open3.capture3(command)
 
     expect(out).to match(output)
-    expect(err).to eq('')
+    expect(err).to eq("")
     expect(status.exitstatus).to eq(0)
 
     within_dir(app_name) do

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -269,7 +269,10 @@ end
   end
 
   context "when app directory contains a whitespace" do
+    subject(:create_app) { Open3.capture3(command) }
+
     let(:app_directory) { "weird dir" }
+    let(:command) { "teletype new app --no-coc --no-color --license mit --no-ext" }
 
     before { FileUtils.mkdir_p("./tmp/#{app_directory}") }
 
@@ -277,8 +280,7 @@ end
 
     it "does not raise errors" do
       within_dir("./tmp/#{app_directory}") do
-        command = "teletype new app --no-coc --no-color --license mit --no-ext"
-        _out, err, _status = Open3.capture3(command)
+        _out, err, _status = create_app
         puts err
         expect(err).to eq('')
       end

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -269,8 +269,7 @@ end
   end
 
   it "does not raise errors if app directory contains whitespace" do
-    app_path = tmp_path("weird dir")
-    Dir.mkdir(app_path)
+    app_path = dir_path("tmp", "weird dir")
 
     command = "teletype new app --no-coc --no-color --license mit --no-ext"
 

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -269,18 +269,15 @@ end
   end
 
   it "does not raise errors if app directory contains whitespace" do
-    app_directory = "weird dir"
-    FileUtils.mkdir_p("./tmp/#{app_directory}")
+    app_path = tmp_path("weird dir")
+    Dir.mkdir(app_path)
 
     command = "teletype new app --no-coc --no-color --license mit --no-ext"
 
-    within_dir("./tmp/#{app_directory}") do
+    within_dir(app_path) do
       _out, err, _status = Open3.capture3(command)
-      puts err
       expect(err).to eq("")
     end
-
-    FileUtils.rm_r("./tmp/#{app_directory}")
   end
 
   it "generates C extensions boilerplate" do
@@ -296,7 +293,7 @@ end
     out, err, status = Open3.capture3(command)
 
     expect(out).to match(output)
-    expect(err).to eq("")
+    expect(err).to eq('')
     expect(status.exitstatus).to eq(0)
 
     within_dir(app_name) do

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -268,6 +268,23 @@ end
     end
   end
 
+  context "when app directory contains a whitespace" do
+    let(:app_directory) { "weird dir" }
+
+    before { FileUtils.mkdir_p("./tmp/#{app_directory}") }
+
+    after { FileUtils.rm_r("./tmp/#{app_directory}") }
+
+    it "does not raise errors" do
+      within_dir("./tmp/#{app_directory}") do
+        command = "teletype new app --no-coc --no-color --license mit --no-ext"
+        _out, err, _status = Open3.capture3(command)
+        puts err
+        expect(err).to eq('')
+      end
+    end
+  end
+
   it "generates C extensions boilerplate" do
     app_name = tmp_path('newcli')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ end
 require 'tty'
 require 'tty-file'
 require 'fileutils'
+require 'shellwords'
 require 'open3'
 
 class String


### PR DESCRIPTION
### Describe the change
Escaping app path via `Shellowords#shellescape`

### Why are we doing this?
Because of Issue #57 

### Benefits
This will allow to create new teletype apps in directories containing whitespaces

### Drawbacks
Possible drawbacks applying this change.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated? [no need]
