### PR TITLE
clarify the need to `cd` before running `teletype` commands in the 'Overview' section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ To simply jump start a new command line application use `teletype` executable:
 $ teletype new app
 ```
 
-and then to add more commands:
+Move in to your new app, and then add more commands:
 
 ```bash
+$ cd app
 $ teletype add config
 ```
 
-Throughout the rest of this guide, I will assume a generated application called `app` and a newly created bare command `config`.
+Throughout the rest of this guide, I will assume a generated application called `app`, that you are in the working directory of 'app/', and a newly created bare command `config`.
 
 ## 2. Bootstrapping
 


### PR DESCRIPTION
### Describe the change
Related to #62 - clarify that one must be in the app directory before commands can be added.

### Why are we doing this?
The documentation makes it seem like one would immediately run `teletype command ...` after making an app, without being in the app directory itself.

### Benefits
More detailed docs!

### Drawbacks
None that I can think of.

### Requirements
Put an X between brackets on each line if you have done the item:
[n/a] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
