### PR TITLE
fail safely on `teletype add` if the current directory is not a teletype app

### DIFF
--- a/spec/integration/add_spec.rb
+++ b/spec/integration/add_spec.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe "`teletype add` command", type: :sandbox do
+  it "shows an error when add is used outside a project directory" do
+    app_name = "notcli"
+    FileUtils.mkdir(app_name)
+
+    within_dir(app_name) do
+      command = "teletype add test --no-color"
+      output  = <<-EOO
+ERROR: This doesn't look like a teletype app directory - are you in the right place?
+      EOO
+
+      out, err, status = Open3.capture3(command)
+
+      expect(out).to match(output)
+      expect(err).to eq("")
+      expect(status.exitstatus).to eq(1)
+    end
+  end
+
   it "adds a command" do
     app_name = "newcli"
     silent_run("teletype new #{app_name} --test rspec")


### PR DESCRIPTION
### Describe the change
Adds a `validate_pwd` method to the "add" command that makes sure that a gemspec & directory exists before trying to create the command.

### Why are we doing this?
A friendly message is better than a stack trace.

### Benefits
This will improve user understanding when accidentally trying to run `teletype add` outside of the project directory.

Should close #62 

### Drawbacks
There's no way to directly check that the pwd is actually a teletype app, vs another app that happens to have the same structure. However, that was the case before too - this just covers one edge case.

### Requirements
Put an X between brackets on each line if you have done the item:
[...] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
