### PR TITLE
add output from `teletype new` that instructs the user to first edit the gemspec file

### DIFF
--- a/lib/tty/commands/new.rb
+++ b/lib/tty/commands/new.rb
@@ -147,8 +147,12 @@ module TTY
         make_executable
         output.puts install_info.join("\n") unless install_info.empty?
 
-        output.print "\n" + @pastel.green("Your teletype project has been created successfully.\n")
-        output.print "\n" + @pastel.green("Run \"teletype help\" for more commands.\n")
+        output.print "\n" + @pastel.green("Your teletype project has been created successfully in directory \"#{app_path}\".\n")
+        output.print "\n" + @pastel.yellow("Before you can begin working, you'll need to modify the \"#{app_path}.gemspec\" file:\n")
+        output.print @pastel.yellow("  - Replace all TODO: text with valid information (summary, description, etc)\n")
+        output.print @pastel.yellow("  - Replace all metadata information (URIs, hosts) with valid URLs, or delete them\n")
+        output.print @pastel.yellow("  - Uncomment any 'spec.add_dependency' lines for tty-* libs you plan on using\n")
+        output.print "\n" + @pastel.green("Then, you can run \"teletype help\" for more commands.\n")
       end
 
       private

--- a/spec/integration/new_namespaced_spec.rb
+++ b/spec/integration/new_namespaced_spec.rb
@@ -32,9 +32,14 @@ Creating gem 'cli-app'...
       create  cli-app/spec/unit/.gitkeep
 Initializing git repo in #{::File.expand_path(app_name)}
 
-Your teletype project has been created successfully.
+Your teletype project has been created successfully in directory "#{app_name}".
 
-Run "teletype help" for more commands.
+Before you can begin working, you'll need to modify the "#{app_name}.gemspec" file:
+  - Replace all TODO: text with valid information (summary, description, etc)
+  - Replace all metadata information (URIs, hosts) with valid URLs, or delete them
+  - Uncomment any 'spec.add_dependency' lines for tty-* libs you plan on using
+
+Then, you can run "teletype help" for more commands.
     OUT
 
     command = "teletype new #{app_name} --no-coc --no-color --license mit"

--- a/spec/integration/new_spec.rb
+++ b/spec/integration/new_spec.rb
@@ -32,9 +32,14 @@ Creating gem 'newcli'...
       create  newcli/spec/unit/.gitkeep
 Initializing git repo in #{::File.expand_path(app_name)}
 
-Your teletype project has been created successfully.
+Your teletype project has been created successfully in directory "#{app_name}".
 
-Run "teletype help" for more commands.
+Before you can begin working, you'll need to modify the "#{app_name}.gemspec" file:
+  - Replace all TODO: text with valid information (summary, description, etc)
+  - Replace all metadata information (URIs, hosts) with valid URLs, or delete them
+  - Uncomment any 'spec.add_dependency' lines for tty-* libs you plan on using
+
+Then, you can run "teletype help" for more commands.
     OUT
 
     command = "teletype new #{app_name} --no-coc --no-color --license mit --no-ext"
@@ -342,9 +347,14 @@ Creating gem 'app'...
       create  app/spec/unit/.gitkeep
 Initializing git repo in #{::File.expand_path(::File.join("weird dir", "app"))}
 
-Your teletype project has been created successfully.
+Your teletype project has been created successfully in directory "app".
 
-Run "teletype help" for more commands.
+Before you can begin working, you'll need to modify the "app.gemspec" file:
+  - Replace all TODO: text with valid information (summary, description, etc)
+  - Replace all metadata information (URIs, hosts) with valid URLs, or delete them
+  - Uncomment any 'spec.add_dependency' lines for tty-* libs you plan on using
+
+Then, you can run "teletype help" for more commands.
     OUT
 
     command = "teletype new app --no-coc --no-color --license mit --no-ext"


### PR DESCRIPTION
### Describe the change
Sort-of resolves #69, at least for the time being until the gemspec stuff is sorted out.

### Why are we doing this?
The situation with the default gemspec file makes creating a new project confusing. This adds more output that instructs the user to modify the gemspec file before doing anything else.

### Benefits
Improved understanding/usability.

### Drawbacks
This is intrinsically a temporary/bandaid change that will be unnecessary once the new gemspec/gem stuff is done.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
