### PR TITLE
Pull request: Fix a bug in setting gemspec license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.rbc
 .bundle
 .config
+.envrc
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/tty/commands/new.rb
+++ b/lib/tty/commands/new.rb
@@ -210,7 +210,7 @@ module TTY
         else
           gem_license = " " * gemspec.pre_var_indent
           gem_license << "#{gemspec.var_name}.license"
-          gem_license << " " * (gemspec.post_var_indent - ".license".size)
+          gem_license << " " * [(gemspec.post_var_indent - ".license".size), 0].max
           gem_license << "= \"#{licenses[license][:name]}\""
           gemspec.content.gsub!(/(^\s*#{gemspec.var_name}\.name\s*=\s*.*$)/,
                                 "\\1\n#{gem_license}")


### PR DESCRIPTION
### Describe the change
Corrects an error I experienced trying to run `teletype new`: the count of spaces to add in padding the license for the gemspec was negative. I fixed this by ensuring that the padding count is always >= 0.

I also added .envrc to the .gitignore file, since I use direnv locally, but I don't think my settings should be included in the repository.

### Why are we doing this?
This bug caused `teletype new` to fail.

### Benefits
This makes the tool more reliable.

### Drawbacks
None

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [ ] Tests written & passing locally?
- [ ] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?

Note: Several test fail -- but they were already failing when I cloned the repo, before I made any changes.
